### PR TITLE
Bump Pydantic to 1.10.20 for Python 3.12 and 3.13

### DIFF
--- a/manager_api/requirements.txt
+++ b/manager_api/requirements.txt
@@ -1,2 +1,2 @@
-pydantic==1.10.4
+pydantic==1.10.20
 requests==2.25.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'manager_api'
     ],
     install_requires=[
-        'pydantic==1.10.4',
+        'pydantic==1.10.20',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
See further discussion and testing against Python 3.10 at https://github.com/isotherm/python-manager-api/issues/3